### PR TITLE
Change config dir to conf.d

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class monit::params {
   case $::osfamily {
     'Debian': {
       $config = '/etc/monit/monitrc'
-      $included = '/etc/monit/monit.d'
+      $included = '/etc/monit/conf.d'
       $idfile = '/var/lib/monit/id'
       $statefile = '/var/lib/monit/state'
       $basedir = '/var/lib/monit/events'


### PR DESCRIPTION
Default debian include dir is conf.d, not monit.d. Changing this to reflect what the monit package installs with.
